### PR TITLE
Separate ZMQ communication from Vicon-related code

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,6 @@ install_requires =
 [options.extras_require]
 test =
     pytest
+
+[options.package_data]
+vicon_transformer = py.typed

--- a/tests/test_vicon_json.py
+++ b/tests/test_vicon_json.py
@@ -4,7 +4,7 @@ import math
 
 import pytest
 
-from vicon_transformer import ViconJson  # noqa
+from vicon_transformer import ViconJsonFile
 
 
 @pytest.fixture
@@ -23,8 +23,8 @@ def test_origin_init(test_data):
         ).reshape(3, 1)
         return w, theta
 
-    vT1 = ViconJson(fname=test_data / "test_frame1.json", timeout_in_ms=0)
-    vT2 = ViconJson(fname=test_data / "test_frame2.json", timeout_in_ms=0)
+    vT1 = ViconJsonFile(test_data / "test_frame1.json")
+    vT2 = ViconJsonFile(test_data / "test_frame2.json")
 
     for key in vT1.json_obj["subjectNames"]:
         # the marker of the Ballmaschine is not very good, better ignore it here

--- a/vicon_transformer/__init__.py
+++ b/vicon_transformer/__init__.py
@@ -1,5 +1,6 @@
-from .vicon_transformer import ViconJson
+from .receiver import ZmqJsonReceiver
+from .vicon_json import ViconJson
 
 __version__ = "1.0.0"
 
-__all__ = ("ViconJson",)
+__all__ = ("ViconJson", "ZmqJsonReceiver")

--- a/vicon_transformer/__init__.py
+++ b/vicon_transformer/__init__.py
@@ -1,6 +1,6 @@
 from .receiver import ZmqJsonReceiver
-from .vicon_json import ViconJson
+from .vicon_json import ViconJsonZmq, ViconJsonFile
 
 __version__ = "1.0.0"
 
-__all__ = ("ViconJson", "ZmqJsonReceiver")
+__all__ = ("ViconJsonZmq", "ViconJsonFile", "ZmqJsonReceiver")

--- a/vicon_transformer/errors.py
+++ b/vicon_transformer/errors.py
@@ -1,0 +1,9 @@
+"""Custom exceptions of vicon_transformer."""
+
+
+class NotConnectedError(Exception):
+    pass
+
+
+class ConnectionFailedError(Exception):
+    pass

--- a/vicon_transformer/receiver.py
+++ b/vicon_transformer/receiver.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import logging
+import typing
+
+import zmq
+
+from .errors import NotConnectedError, ConnectionFailedError
+
+
+class ZmqJsonReceiver:
+    """Connect to a socket and receive JSON data via zmq.
+
+    This class can be used in a ``with`` statement:
+
+    .. code-block:: Python
+
+        with ZmqJsonReceiver(...) as receiver:
+            data = receiver.read()
+
+    If used without ``with``, make sure to call :meth:`connect` and :meth:`close`:
+
+    .. code-block:: Python
+
+        receiver = ZmqJsonReceiver(...)
+        receiver.connect()
+        data = receiver.read()
+        receiver.close()
+    """
+
+    def __init__(
+        self,
+        address: str = "tcp://10.42.2.29:5555",
+        timeout_ms: int = 5000,
+    ) -> None:
+        """
+        Args:
+            address:  Address to which the ZMQ socket is connected.  Any protocol that
+                is supported by ZMQ can be used.
+            timeout_ms:  For how long to wait when no message is received.
+                In milliseconds.
+        """
+        self.log = logging.getLogger(__name__)
+
+        # type declarations
+        self.socket: zmq.Socket
+        self.context: zmq.Context
+
+        self.is_connected = False
+        self.address = address
+        self.timeout_ms = timeout_ms
+
+    def __del__(self) -> None:
+        if self.is_connected:
+            self.close()
+
+    def __enter__(self) -> ZmqJsonReceiver:
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    def connect(self) -> None:
+        """Connect to the address given to the constructor.
+
+        Raises:
+            ConnectionFailedError:  If connection cannot be established.
+        """
+        try:
+            self.context = zmq.Context()
+            self.socket = self.context.socket(zmq.SUB)
+            self.socket.setsockopt(zmq.SUBSCRIBE, b"")
+            self.socket.RCVTIMEO = self.timeout_ms
+
+            self.log.info("Connect to %s", self.address)
+            self.socket.connect(self.address)
+
+            if self.socket.closed is True:
+                raise ConnectionFailedError()
+
+            self.is_connected = True
+        except Exception as e:
+            raise ConnectionFailedError(f"could not connect: {e}")
+
+    def close(self) -> None:
+        """Close connection.  Does nothing if not currently connected."""
+        self.log.debug("disconnect: disconnecting...")
+        if self.is_connected:
+            self.context.destroy()
+            if self.socket.closed is True:
+                self.is_connected = False
+                self.log.info("disconnected. Bye...")
+            else:
+                self.log.error("disconnecting failed!")
+        else:
+            self.log.info("already disconnected. Bye...")
+
+    def read(self) -> typing.Any:
+        """Read one json object from the socket.
+
+        Returns:
+            The received data.
+
+        Raises:
+            NotConnectedError:  If called without using a context manager or calling
+                :meth:`connect()` first.
+        """
+        if not self.is_connected:
+            raise NotConnectedError()
+
+        return self.socket.recv_json()

--- a/vicon_transformer/receiver.py
+++ b/vicon_transformer/receiver.py
@@ -40,7 +40,10 @@ class ZmqJsonReceiver:
             timeout_ms:  For how long to wait when no message is received.
                 In milliseconds.
         """
-        self._log = logging.getLogger(__name__)
+        logger = logging.getLogger(__name__)
+        self._log = logging.LoggerAdapter(
+            logger, {"className": self.__class__.__name__, "address": address}
+        )
 
         # type declarations
         self._socket: zmq.Socket

--- a/vicon_transformer/receiver.py
+++ b/vicon_transformer/receiver.py
@@ -40,18 +40,18 @@ class ZmqJsonReceiver:
             timeout_ms:  For how long to wait when no message is received.
                 In milliseconds.
         """
-        self.log = logging.getLogger(__name__)
+        self._log = logging.getLogger(__name__)
 
         # type declarations
-        self.socket: zmq.Socket
-        self.context: zmq.Context
+        self._socket: zmq.Socket
+        self._context: zmq.Context
 
-        self.is_connected = False
-        self.address = address
-        self.timeout_ms = timeout_ms
+        self._is_connected = False
+        self._address = address
+        self._timeout_ms = timeout_ms
 
     def __del__(self) -> None:
-        if self.is_connected:
+        if self._is_connected:
             self.close()
 
     def __enter__(self) -> ZmqJsonReceiver:
@@ -68,33 +68,33 @@ class ZmqJsonReceiver:
             ConnectionFailedError:  If connection cannot be established.
         """
         try:
-            self.context = zmq.Context()
-            self.socket = self.context.socket(zmq.SUB)
-            self.socket.setsockopt(zmq.SUBSCRIBE, b"")
-            self.socket.RCVTIMEO = self.timeout_ms
+            self._context = zmq.Context()
+            self._socket = self._context.socket(zmq.SUB)
+            self._socket.setsockopt(zmq.SUBSCRIBE, b"")
+            self._socket.RCVTIMEO = self._timeout_ms
 
-            self.log.info("Connect to %s", self.address)
-            self.socket.connect(self.address)
+            self._log.info("Connect to %s", self._address)
+            self._socket.connect(self._address)
 
-            if self.socket.closed is True:
+            if self._socket.closed is True:
                 raise ConnectionFailedError()
 
-            self.is_connected = True
+            self._is_connected = True
         except Exception as e:
             raise ConnectionFailedError(f"could not connect: {e}")
 
     def close(self) -> None:
         """Close connection.  Does nothing if not currently connected."""
-        self.log.debug("disconnect: disconnecting...")
-        if self.is_connected:
-            self.context.destroy()
-            if self.socket.closed is True:
-                self.is_connected = False
-                self.log.info("disconnected. Bye...")
+        self._log.debug("disconnect: disconnecting...")
+        if self._is_connected:
+            self._context.destroy()
+            if self._socket.closed is True:
+                self._is_connected = False
+                self._log.info("disconnected. Bye...")
             else:
-                self.log.error("disconnecting failed!")
+                self._log.error("disconnecting failed!")
         else:
-            self.log.info("already disconnected. Bye...")
+            self._log.info("already disconnected. Bye...")
 
     def read(self) -> typing.Any:
         """Read one json object from the socket.
@@ -106,7 +106,7 @@ class ZmqJsonReceiver:
             NotConnectedError:  If called without using a context manager or calling
                 :meth:`connect()` first.
         """
-        if not self.is_connected:
+        if not self._is_connected:
             raise NotConnectedError()
 
-        return self.socket.recv_json()
+        return self._socket.recv_json()


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Move the part related to ZMQ communication out of `ViconJson` into its own class `ZmqJsonReceiver` to make it reusable.
Also refactor the code a bit and improve error handling.


## How I Tested

By using ViconJson it in a test script.



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
