### PR TITLE
Add scripts to record and play back data

### DIFF
--- a/scripts/playback.py
+++ b/scripts/playback.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Play back Vicon data from a previously recorded pickle file."""
+import argparse
+import logging
+import pathlib
+import pickle
+import sys
+import time
+
+import tqdm
+import zmq  # type: ignore
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "address",
+        type=str,
+        nargs="?",
+        default="tcp://10.42.2.29:5555",
+        help="Address to connect the zmq socket to.  Default: %(default)s.",
+    )
+    parser.add_argument(
+        "input_file", type=pathlib.Path, help="File with the recorded data."
+    )
+    args = parser.parse_args()
+
+    try:
+        with open(args.input_file, "rb") as f:
+            data = pickle.load(f)
+    except FileNotFoundError:
+        logging.fatal("File %s does not exists.", args.input_file)
+        return 1
+    except Exception as e:
+        logging.fatal("Failed to read file %s.  Error: %s", args.input_file, e)
+        return 1
+
+    with zmq.Context() as context:
+        with context.socket(zmq.PUB) as socket:
+            logging.info("Publish to %s", args.address)
+            socket.bind(args.address)
+
+            logging.info("start playback")
+            stamp_0 = data[0]["time_stamp"]
+            now = time.time_ns()
+            time_offset = now - stamp_0
+
+            for frame in tqdm.tqdm(data):
+                # wait until next frame is due
+                now = time.time_ns()
+                while now - time_offset <= frame["time_stamp"]:
+                    time.sleep(0.001)
+                    now = time.time_ns()
+                socket.send_json(frame)
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        logging.info("You pressed Ctrl+C -> stop playback")
+        sys.exit(2)

--- a/scripts/recorder.py
+++ b/scripts/recorder.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Record data received from the Vicon system and save to a pickle file."""
+import argparse
+import logging
+import pathlib
+import pickle
+import signal
+import sys
+import time
+import typing
+
+import tqdm
+import zmq  # type: ignore
+
+
+class DurationEnd(Exception):
+    ...
+
+
+class ZmqRecorder:
+    def __init__(self):
+        self.stop_requested = False
+
+    def _signal_handler(self, sig, frame):
+        logging.info("You pressed Ctrl+C -> stop recording")
+        self.stop_requested = True
+
+    def record(
+        self, address: str, output_file: pathlib.Path, duration: typing.Optional[float]
+    ) -> None:
+        self.stop_requested = False
+
+        signal.signal(signal.SIGINT, self._signal_handler)
+
+        logging.info("Connect to %s", address)
+        context = zmq.Context()
+        sub = context.socket(zmq.SUB)
+        sub.setsockopt(zmq.SUBSCRIBE, b"")
+        sub.RCVTIMEO = 5000  # wait only 5s for new message
+        sub.connect(address)
+
+        if duration:
+            print("Start recording for %.0f seconds." % duration)
+        else:
+            print("Start recording.  Press Ctrl+C to stop.")
+
+        t_start = time.time()
+        data = []
+        try:
+            with tqdm.tqdm() as progress:
+                while not self.stop_requested:
+                    j = sub.recv_json()
+                    data.append(j)
+                    progress.update()
+
+                    if duration and (time.time() - t_start) > duration:
+                        raise DurationEnd()
+
+        except DurationEnd:
+            logging.info("Stop recording after %.1f seconds.", duration)
+
+        except Exception as e:
+            logging.error("Error [%s]: %s", type(e), e)
+            logging.info("Stop recording.")
+
+        context.destroy()
+
+        record_duration_s = (data[-1]["time_stamp"] - data[0]["time_stamp"]) / 1e9
+        logging.info(
+            "Save %d frames (%.1f seconds) to %s",
+            len(data),
+            record_duration_s,
+            output_file,
+        )
+        with open(output_file, "wb") as f:
+            pickle.dump(data, f, pickle.HIGHEST_PROTOCOL)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "address",
+        type=str,
+        nargs="?",
+        default="tcp://10.42.2.29:5555",
+        help="Address to connect the zmq socket to.  Default: %(default)s.",
+    )
+    parser.add_argument("output_file", type=pathlib.Path, help="Output destination.")
+    parser.add_argument(
+        "--duration",
+        "-d",
+        type=float,
+        metavar="SECONDS",
+        help="Automatically stop recording after the specified number of seconds.",
+    )
+    args = parser.parse_args()
+
+    if args.output_file.exists():
+        logging.fatal("File %s already exists.", args.output_file)
+        return 1
+
+    recorder = ZmqRecorder()
+    recorder.record(**vars(args))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ project_urls =
 packages = find:
 install_requires =
     numpy
+    tqdm
     zmq
 
 [options.extras_require]


### PR DESCRIPTION
## Description

Add two scripts `recorder.py` and `playback.py` to record data received from the Vicon system to a pickle file and play it back later.
The purpose is mostly to make development easier as the recorded data can be used for testing without access to the actual Vicon system.

Also add an "address" argument to `receiver.py`, so it can be used more flexibly (e.g. in combination with `playback.py`).


## How I Tested

I used it to record some data which I am now using to test changes on the code.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
