### PR TITLE
Use the Transformation class instead of matrices

### DIFF
--- a/vicon_transformer/vicon_json.py
+++ b/vicon_transformer/vicon_json.py
@@ -7,43 +7,19 @@ import numpy as np
 from .receiver import ZmqJsonReceiver
 from .transform import Transformation, Rotation
 
-# object names
-# ['frame_number', 'frame_rate', 'latency', 'my_frame_number', 'num_subjects',
-# 'on_time', 'subjectNames', 'subject_0', 'subject_1', 'subject_2', 'subject_3',
-# 'subject_4', 'subject_5', 'subject_6', 'subject_7', 'subject_8', 'subject_9',
-# 'time_stamp']
-
-
-def T(R, p):
-    tmp = np.eye(4)
-    tmp[:3, :3] = np.array(R).reshape(3, 3)
-    tmp[:3, 3:4] = np.array(p).reshape(3, 1)
-    return tmp
-
-
-def inv_T(T):
-    invT = T.copy()
-    invT[:3, :3] = T[:3, :3].T
-    invT[:3, 3:4] = -invT[:3, :3].dot(T[:3, 3:4])
-    return invT
-
-
-def get_translation(T: np.ndarray) -> np.ndarray:
-    return T[:3, 3]
-
 
 class ViconJsonBase:
     FORMAT_VERSION = 2
 
     def __init__(self) -> None:
         self.log = logging.getLogger(__name__)
-        self.T_origin_vicon = np.eye(4)
+        self.T_origin_vicon = Transformation.identity()
 
         self.json_obj: typing.Dict
 
     def _init_origin(self) -> None:
         originKey = "rll_ping_base"
-        self.T_origin_vicon = inv_T(self.get_T(originKey))
+        self.T_origin_vicon = self.get_T(originKey).inv()
 
     def _check_format_version(self, record):
         format_version = record.get("format_version")
@@ -59,11 +35,11 @@ class ViconJsonBase:
     def get_subject_names(self) -> typing.List[str]:
         return list(self.json_obj["subjects"].keys())
 
-    def print_distances(self):
-        t_pos_1 = self.get_table1_T()[:3, -1]
-        t_pos_2 = self.get_table2_T()[:3, -1]
-        t_pos_3 = self.get_table3_T()[:3, -1]
-        t_pos_4 = self.get_table4_T()[:3, -1]
+    def print_distances(self) -> None:
+        t_pos_1 = self.get_table1_T().translation
+        t_pos_2 = self.get_table2_T().translation
+        t_pos_3 = self.get_table3_T().translation
+        t_pos_4 = self.get_table4_T().translation
 
         print("table lengths")
         print("1->4 ", np.linalg.norm(t_pos_1 - t_pos_4))
@@ -72,7 +48,7 @@ class ViconJsonBase:
         print("4->3 ", np.linalg.norm(t_pos_4 - t_pos_3))
 
         print("distance origin -> robot vicon marker")
-        t_rob_origin = self.get_robot_base_T()[:3, -1]
+        t_rob_origin = self.get_robot_base_T().translation
         print(t_rob_origin)
 
     # get object rotations and translations
@@ -93,51 +69,49 @@ class ViconJsonBase:
 
         return np.squeeze(np.asarray(r_rot_xy_))
 
-    def get_robot_shoulder_T(self):
+    def get_robot_shoulder_T(self) -> Transformation:
         # TODO: Orientation is left the same with the base orientation
-        #       shoulder is located at [-.255,.0785,0] in base frame
-        T_base_shoulder = np.eye(4)
-        T_base_shoulder[:3, -1] = np.asarray(
-            [-0.255, 0.0785, 0]
-        )  # measured on real robot
+        #       shoulder is located at [-.255,.0785,0] in base frame (measured on real
+        #       robot)
+        T_base_shoulder = Transformation(translation=[-0.255, 0.0785, 0])
         T_orig_base = self.get_robot_base_T()
-        return T_orig_base @ T_base_shoulder
+        return T_orig_base * T_base_shoulder
 
-    def get_table_pos(self):
-        t_pos_1 = get_translation(self.get_table1_T())
-        t_pos_2 = get_translation(self.get_table2_T())
-        t_pos_3 = get_translation(self.get_table3_T())
-        t_pos_4 = get_translation(self.get_table4_T())
+    def get_table_pos(self) -> np.ndarray:
+        t_pos_1 = self.get_table1_T().translation
+        t_pos_2 = self.get_table2_T().translation
+        t_pos_3 = self.get_table3_T().translation
+        t_pos_4 = self.get_table4_T().translation
         t = (t_pos_1 + t_pos_2 + t_pos_3 + t_pos_4) / 4
 
         return t
 
     # Transformations
-    def get_robot_base_T(self):
+    def get_robot_base_T(self) -> Transformation:
         return self.get_T("rll_muscle_base")
 
-    def get_table1_T(self):
+    def get_table1_T(self) -> Transformation:
         return self.get_T("TT Platte_Eckteil 1")
 
-    def get_table2_T(self):
+    def get_table2_T(self) -> Transformation:
         return self.get_T("TT Platte_Eckteil 2")
 
-    def get_table3_T(self):
+    def get_table3_T(self) -> Transformation:
         return self.get_T("TT Platte_Eckteil 3")
 
-    def get_table4_T(self):
+    def get_table4_T(self) -> Transformation:
         return self.get_T("TT Platte_Eckteil 4")
 
     # access json methods
-    def get_T(self, subject_name):
+    def get_T(self, subject_name: str) -> Transformation:
         # Returns homogenous transformation in origin frame
 
         subject_data = self.json_obj["subjects"][subject_name]
         translation = 1e-3 * np.asarray(subject_data["global_translation"][0])
         rotation = Rotation(subject_data["global_rotation"]["quaternion"][0])
-        T = Transformation(rotation, translation)
+        tf = Transformation(rotation, translation)
 
-        return self.T_origin_vicon @ T.as_matrix()
+        return self.T_origin_vicon * tf
 
 
 class ViconJsonZmq(ViconJsonBase):


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Complete replace usage of transformation matrices with the new `Transformation` class.
This makes the code more readable (clear access to `rotation` and `translation` members instead of error-prone slicing) and should also be more efficient (less computations needed for applying a quaternion compared to a rotation matrix).


## How I Tested

Unit tests and some tests with recorded data.

## Do not merge before

- #14 

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
