### PR TITLE
Add PamVicon class for easier access to relevant Vicon data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,11 +129,17 @@ if(BUILD_TESTING)
     find_package(ament_cmake_gmock REQUIRED)
 
     # Python tests
+    # Note: The default working directory for tests run by colon is the package root.
+    # Python tests that use the C++ bindings need to be run in a different directory,
+    # otherwise the local Python source will shadow the installed package and thus the
+    # pybind11 modules will be missing.
     ament_add_pytest_test(test_transform_py tests/test_transform.py
         WORKING_DIRECTORY /tmp)
     ament_add_pytest_test(test_vicon_transformer_py tests/test_vicon_transformer.py
         WORKING_DIRECTORY /tmp)
     ament_add_pytest_test(test_o80_py tests/test_o80.py
+        WORKING_DIRECTORY /tmp)
+    ament_add_pytest_test(test_pam_vicon_py tests/test_pam_vicon.py
         WORKING_DIRECTORY /tmp)
 
     # C++ tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ find_package(vicon-datastream-sdk REQUIRED)
 ament_export_dependencies(fmt spdlog vicon-datastream-sdk)
 
 ament_python_install_package(${PROJECT_NAME} PACKAGE_DIR ${PROJECT_NAME})
+# TODO move to separate package
+ament_python_install_package(pam_vicon_o80 PACKAGE_DIR pam_vicon_o80)
 
 
 add_library(vicon_receiver

--- a/pam_vicon_o80/__init__.py
+++ b/pam_vicon_o80/__init__.py
@@ -1,0 +1,5 @@
+"""Interface for the PAM Vicon system."""
+from .pam_vicon import PamVicon, NoFrameDataError
+
+
+__all__ = ("PamVicon", "NoFrameDataError")

--- a/pam_vicon_o80/pam_vicon.py
+++ b/pam_vicon_o80/pam_vicon.py
@@ -21,6 +21,7 @@ class NoFrameDataError(RuntimeError):
 
 def get_table_pose(
     corner_positions_world: t.Sequence[np.ndarray],
+    *,
     yaw_only: bool = False,
     table_length: float = 2.740,
     table_width: float = 1.525,
@@ -147,7 +148,7 @@ class PamVicon:
         ]
         corner_positions_world = [c.translation for c in corner_poses_world]
 
-        return get_table_pose(corner_positions_world, yaw_only)
+        return get_table_pose(corner_positions_world, yaw_only=yaw_only)
 
     def get_robot_pose(self) -> Transformation:
         """Get pose of the robot base."""

--- a/pam_vicon_o80/pam_vicon.py
+++ b/pam_vicon_o80/pam_vicon.py
@@ -20,7 +20,10 @@ class NoFrameDataError(RuntimeError):
 
 
 def get_table_pose(
-    corner_positions_world: t.Sequence[np.ndarray], yaw_only: bool = False
+    corner_positions_world: t.Sequence[np.ndarray],
+    yaw_only: bool = False,
+    table_length: float = 2.740,
+    table_width: float = 1.525,
 ) -> Transformation:
     """Get pose of the table based on positions of the corner markers.
 
@@ -28,35 +31,43 @@ def get_table_pose(
 
     ::
 
-        1┌─────────┐2
-         │  y      │
-         │  ▲      │
-         │  │      │
-         │  │    x │
-         │  └───>  │
-         │         │
-        4└─────────┘3
+        1┌───────────┐2
+         │           │
+         │   y       │     l
+         │   ▲       │     e
+         │   │       │     n
+         │   │    x  │     g
+         │   └───>   │     t
+         │           │     h
+         │           │
+        4└───────────┘3
+
+             width
+
+
+    The default values for table length and width are based on the ITTF rules [1].
+
+
+    [1] https://documents.ittf.sport/document/284
+
 
     Args:
         corner_positions_world:  Positions of the table corners in world frame.  See
             above for the expected order.
         yaw_only:  If true, only the yaw angle of the tables orientation is used
             (i.e. assume that the table is flat on the ground).
+        table_length:  Length of the table in metres.
+        table_width:  Width of the table in metres.
     """
-    # table dimensions (assuming a standard table tennis table)
-    # https://www.tabletennisspot.com/knowing-the-dimensions-of-table-tennis-table
-    TABLE_LENGTH = 2.740
-    TABLE_WIDTH = 1.525
-
-    DX = TABLE_WIDTH / 2
-    DY = TABLE_LENGTH / 2
+    dx = table_width / 2
+    dy = table_length / 2
     # see docstring for expected order of corners
     corner_vectors_table_frame = np.array(
         [
-            [-DX, DY, 0],
-            [DX, DY, 0],
-            [DX, -DY, 0],
-            [-DX, -DY, 0],
+            [-dx, dy, 0],
+            [dx, dy, 0],
+            [dx, -dy, 0],
+            [-dx, -dy, 0],
         ]
     )
 

--- a/pam_vicon_o80/pam_vicon.py
+++ b/pam_vicon_o80/pam_vicon.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
 """Wrapper around PAM Vicon o80 front end."""
 import logging
 import typing as t
@@ -44,7 +45,7 @@ def get_table_pose(
     """
     # table dimensions (assuming a standard table tennis table)
     # https://www.tabletennisspot.com/knowing-the-dimensions-of-table-tennis-table
-    TABLE_LENGTH = 0.274
+    TABLE_LENGTH = 2.740
     TABLE_WIDTH = 1.525
 
     DX = TABLE_WIDTH / 2

--- a/pam_vicon_o80/pam_vicon.py
+++ b/pam_vicon_o80/pam_vicon.py
@@ -1,0 +1,143 @@
+"""Wrapper around PAM Vicon o80 front end."""
+import logging
+import typing as t
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from vicon_transformer import pam_vicon_o80, SubjectNotVisibleError, SubjectData
+from vicon_transformer.transform import Transformation
+
+from vicon_transformer.pam_vicon_o80 import get_subject_names, Subjects
+
+
+class NoFrameDataError(RuntimeError):
+    """Error indicating that called method needs Vicon frame data."""
+
+    def __init__(self) -> None:
+        super().__init__("No frame data.  Call `update()` first.")
+
+
+def get_table_pose(
+    corner_positions_world: t.Sequence[np.ndarray], yaw_only: bool = False
+) -> Transformation:
+    """Get pose of the table based on positions of the corner markers.
+
+    Expected order of the table corners:
+
+    ::
+
+        1┌─────────┐2
+         │  y      │
+         │  ▲      │
+         │  │      │
+         │  │    x │
+         │  └───>  │
+         │         │
+        4└─────────┘3
+
+    Args:
+        corner_positions_world:  Positions of the table corners in world frame.  See
+            above for the expected order.
+        yaw_only:  If true, only the yaw angle of the tables orientation is used
+            (i.e. assume that the table is flat on the ground).
+    """
+    # table dimensions (assuming a standard table tennis table)
+    # https://www.tabletennisspot.com/knowing-the-dimensions-of-table-tennis-table
+    TABLE_LENGTH = 0.274
+    TABLE_WIDTH = 1.525
+
+    DX = TABLE_WIDTH / 2
+    DY = TABLE_LENGTH / 2
+    # see docstring for expected order of corners
+    corner_vectors_table_frame = np.array(
+        [
+            [-DX, DY, 0],
+            [DX, DY, 0],
+            [DX, -DY, 0],
+            [-DX, -DY, 0],
+        ]
+    )
+
+    # For the table's position in world frame, simply use the centroid between the
+    # corners.
+    table_position_world = np.mean(corner_positions_world, axis=0)
+
+    # Remove the translational part from the corner positions in world frame.  To my
+    # understanding, this is not really necessary as it is anyway done as a first
+    # step in the Kabsch algorithm, which is implemented in
+    # Rotation.align_vectors(). However, the documentation does not explicitly
+    # mention this and asks for vectors rather then points, so better already do it
+    # here to be on the safe side (i.e. in case they change the implementation in a
+    # future release).
+    corner_vectors_world_frame = corner_positions_world - table_position_world
+
+    # get rotation of the table in world frame
+    table_rot, rssd = Rotation.align_vectors(
+        corner_vectors_world_frame, corner_vectors_table_frame
+    )
+
+    logging.info("Table position: %s", table_position_world)
+    logging.info("Table rotation (XYZ): %s", table_rot.as_euler("XYZ"))
+    logging.info("Table rotation rssd: %s", rssd)
+
+    if yaw_only:
+        logging.info("Only use yaw angle of table rotation.")
+        table_rot_euler = table_rot.as_euler("XYZ")
+        table_rot = Rotation.from_euler("Z", table_rot_euler[2])
+
+    return Transformation(table_rot, table_position_world)
+
+
+class PamVicon:
+    """Wrapper around o80 FrontEnd to more easily access PAM Vicon data."""
+
+    ROBOT_BASE_SUBJECT = pam_vicon_o80.Subjects.MUSCLE_BASE
+    TABLE_CORNER_SUBJECTS = (
+        pam_vicon_o80.Subjects.TABLE_CORNER_1,
+        pam_vicon_o80.Subjects.TABLE_CORNER_2,
+        pam_vicon_o80.Subjects.TABLE_CORNER_3,
+        pam_vicon_o80.Subjects.TABLE_CORNER_4,
+    )
+
+    def __init__(self, segment_id: str) -> None:
+        """
+        Args:
+            segment_id: Shared memory segment ID used by the o80 back end.
+        """
+        self.frontend = pam_vicon_o80.FrontEnd(segment_id)
+        self._frame: t.Optional[pam_vicon_o80.FixedSizeViconFrame] = None
+
+    def update(self) -> None:
+        """Update with latest Vicon data."""
+        self._frame = self.frontend.latest().get_extended_state()
+
+    def _get_subject(self, index: Subjects) -> SubjectData:
+        if self._frame is None:
+            raise NoFrameDataError
+
+        subject_data = self._frame.subjects[index]
+
+        if not subject_data.is_visible:
+            raise SubjectNotVisibleError(get_subject_names()[index])
+
+        return subject_data
+
+    def get_table_pose(self, yaw_only: bool = False) -> Transformation:
+        """Get pose of the table based on poses of the corner markers.
+
+        Args:
+            yaw_only:  If true, only the yaw angle of the tables orientation is used
+                (i.e. assume that the table is flat on the ground).
+        """
+        corner_poses_world = [
+            self._get_subject(sub).global_pose for sub in self.TABLE_CORNER_SUBJECTS
+        ]
+        corner_positions_world = [c.translation for c in corner_poses_world]
+
+        return get_table_pose(corner_positions_world, yaw_only)
+
+    def get_robot_pose(self) -> Transformation:
+        """Get pose of the robot base."""
+        pose = self._get_subject(self.ROBOT_BASE_SUBJECT).global_pose
+        return Transformation(pose.get_rotation(), pose.translation)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,29 +9,36 @@ select = ["ALL"]
 extend-ignore = [
     "BLE",
     "COM",
+    "EM",
     "FBT",
     "INP",
+    "PTH",
     "S",
     "T20",
     "UP",
+    "A003",
     "ANN101",
     "ANN102",
     "ANN401",
+    "D105",
     "D107",
     "D205",
     "D212",
     "G004",
     "I001",
+    "N806",
     "PTH123",
+    "TRY003",
     "TRY400",
 ]
-line-length = 88  # black
 target-version = "py38"
 
 [tool.ruff.pydocstyle]
 convention = "google"
 
 [tool.ruff.per-file-ignores]
+"*.pyi" = ["ALL"]
+"__init__.py" = ["F401"]  # unused imports
 "tests/*" = ["D", "ANN", "PLR2004"]
 "scripts/*" = ["D"]
 

--- a/scripts/get_scene_configuration.py
+++ b/scripts/get_scene_configuration.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Get data from Vicon server and print poses of robot, table and ball machine in JSON
+format.
+"""
+import argparse
+import contextlib
+import json
+import logging
+import pathlib
+import sys
+import typing as t
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from vicon_transformer import (
+    PlaybackReceiver,
+    ViconReceiverConfig,
+    ViconReceiver,
+    ViconTransformer,
+)
+from vicon_transformer.vicon_transformer_bindings import Transformation, Receiver
+
+
+ROBOT_BASE_SUBJECT = "rll_muscle_base"
+BALL_MACHINE_SUBJECT = "Marker Ballmaschine"
+TABLE_CORNER_SUBJECTS = (
+    "TT Platte_Eckteil 1",
+    "TT Platte_Eckteil 2",
+    "TT Platte_Eckteil 3",
+    "TT Platte_Eckteil 4",
+)
+
+
+class JsonEncoder(json.JSONEncoder):
+    """JSON encoder that handles custom types used here"""
+
+    def default(self, obj: t.Any) -> t.Any:
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        if isinstance(obj, Transformation):
+            tf_dict = {
+                "position": obj.translation,
+                "orientation": obj.get_rotation(),
+            }
+            return tf_dict
+        return json.JSONEncoder.default(self, obj)
+
+
+def get_table_transform(transformer: ViconTransformer) -> Transformation:
+    """Get pose of the table based on poses of the corner markers."""
+    # table dimensions (assuming a standard table tennis table)
+    # https://www.tabletennisspot.com/knowing-the-dimensions-of-table-tennis-table
+    TABLE_LENGTH = 0.274
+    TABLE_WIDTH = 1.525
+
+    # IDs of the corners:
+    #
+    #  1┌─────────┐2
+    #   │  y      │
+    #   │  ▲      │
+    #   │  │      │
+    #   │  │    x │
+    #   │  └───>  │
+    #   │         │
+    #  4└─────────┘3
+
+    DX = TABLE_WIDTH / 2
+    DY = TABLE_LENGTH / 2
+    corner_vectors_table_frame = np.array(
+        [
+            [-DX, DY, 0],
+            [DX, DY, 0],
+            [DX, -DY, 0],
+            [-DX, -DY, 0],
+        ]
+    )
+
+    corner_poses_world = [
+        transformer.get_transform(name) for name in TABLE_CORNER_SUBJECTS
+    ]
+    corner_positions_world = [c.translation for c in corner_poses_world]
+
+    # For the table's position in world frame, simply use the centroid between the
+    # corners.
+    table_position_world = np.mean(corner_positions_world, axis=0)
+
+    # Remove the translational part from the corner positions in world frame.  To my
+    # understanding, this is not really necessary as it is anyway done as a first step
+    # in the Kabsch algorithm, which is implemented in Rotation.align_vectors().
+    # However, the documentation does not explicitly mention this and asks for vectors
+    # rather then points, so better already do it here to be on the safe side (i.e. in
+    # case they change the implementation in a future release).
+    corner_vectors_world_frame = corner_positions_world - table_position_world
+
+    # get rotation of the table in world frame
+    table_rot, rssd = Rotation.align_vectors(
+        corner_vectors_world_frame, corner_vectors_table_frame
+    )
+
+    logging.info("Table position: %s", table_position_world)
+    logging.info("Table rotation (XYZ): %s", table_rot.as_euler("XYZ"))
+    logging.info("Table rotation rssd: %s", rssd)
+
+    table_tf = Transformation()
+    table_tf.translation = table_position_world
+    table_tf.set_rotation(table_rot.as_quat())
+
+    return table_tf
+
+
+def main() -> int:
+    # parse arguments
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "host_or_file",
+        type=str,
+        help="Hostname of Vicon server or path to recorded file.",
+    )
+    parser.add_argument(
+        "--origin-subject",
+        "-o",
+        type=str,
+        default="rll_ping_base",
+        help="Name of the origin marker (used as origin for the world frame).",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+
+    receiver: Receiver
+    if (filename := pathlib.Path(args.host_or_file)).is_file():
+        receiver = PlaybackReceiver(filename)
+    else:
+        config = ViconReceiverConfig()
+        receiver = ViconReceiver(args.host_or_file, config)
+        receiver.connect()
+
+    transformer = ViconTransformer(receiver, args.origin_subject)
+    transformer.wait_for_origin_subject_data()
+
+    transformer.update()
+
+    output = {
+        "robot": transformer.get_transform(ROBOT_BASE_SUBJECT),
+        "ball_machine": transformer.get_transform(BALL_MACHINE_SUBJECT),
+        "table": get_table_transform(transformer),
+    }
+
+    print(json.dumps(output, indent=4, cls=JsonEncoder))
+
+    return 0
+
+
+if __name__ == "__main__":
+    with contextlib.suppress(KeyboardInterrupt):
+        sys.exit(main())

--- a/tests/test_o80.py
+++ b/tests/test_o80.py
@@ -27,7 +27,7 @@ def test_data():
 
 
 @pytest.fixture()
-def _burst_standalone(test_data):
+def _standalone(test_data):
     # Set up a standalone with a JsonReceiver, that always provides the observation
     # loaded from the file
     receiver = JsonReceiver(test_data / "frame_ping_simple_translation.json")
@@ -43,7 +43,7 @@ def _burst_standalone(test_data):
     stop_standalone(SEGMENT_ID)
 
 
-@pytest.mark.usefixtures("_burst_standalone")
+@pytest.mark.usefixtures("_standalone")
 def test_o80_basic() -> None:
     # create a front end and receive one observation
     frontend = FrontEnd(SEGMENT_ID)

--- a/tests/test_pam_vicon.py
+++ b/tests/test_pam_vicon.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: BSD-3-Clause
+"""Test functions/classes of the pam_vicon module."""
+import pathlib
+
+import pytest
+from numpy.testing import assert_array_almost_equal
+from scipy.spatial.transform import Rotation
+
+import o80
+from vicon_transformer.vicon_transformer_bindings import (
+    JsonReceiver,
+)
+from vicon_transformer.pam_vicon_o80 import (
+    start_standalone,
+    stop_standalone,
+)
+
+from pam_vicon_o80 import pam_vicon
+
+
+TABLE_LENGTH = 2.740
+TABLE_WIDTH = 1.525
+SEGMENT_ID = "test_vicon"
+ORIGIN_SUBJECT = "rll_ping_base"
+
+
+@pytest.fixture()
+def test_data():
+    return pathlib.PurePath(__file__).parent / "data"
+
+
+@pytest.fixture()
+def _standalone(test_data):
+    # Set up a standalone with a JsonReceiver, that always provides the observation
+    # loaded from the file
+    receiver = JsonReceiver(test_data / "frame_ping_simple_translation.json")
+
+    o80.clear_shared_memory(SEGMENT_ID)
+    frequency = 10
+    burst = False
+    start_standalone(SEGMENT_ID, frequency, burst, receiver, ORIGIN_SUBJECT)
+
+    yield
+
+    # tear down
+    stop_standalone(SEGMENT_ID)
+
+
+def test_get_table_pose_at_origin():
+    DX = TABLE_WIDTH / 2
+    DY = TABLE_LENGTH / 2
+    corners = [
+        [-DX, DY, 0],
+        [DX, DY, 0],
+        [DX, -DY, 0],
+        [-DX, -DY, 0],
+    ]
+
+    pose = pam_vicon.get_table_pose(corners)
+
+    assert_array_almost_equal(pose.translation, [0, 0, 0])
+    assert_array_almost_equal(pose.rotation.as_quat(), [0, 0, 0, 1])
+
+
+def test_get_table_pose_translated():
+    DX = TABLE_WIDTH / 2
+    DY = TABLE_LENGTH / 2
+    corners = [
+        [-DX + 1.2, DY - 0.7, 1.4],
+        [DX + 1.2, DY - 0.7, 1.4],
+        [DX + 1.2, -DY - 0.7, 1.4],
+        [-DX + 1.2, -DY - 0.7, 1.4],
+    ]
+
+    pose = pam_vicon.get_table_pose(corners)
+
+    assert_array_almost_equal(pose.translation, [1.2, -0.7, 1.4])
+    assert_array_almost_equal(pose.rotation.as_quat(), [0, 0, 0, 1])
+
+
+def test_get_table_pose_rotated():
+    DX = TABLE_WIDTH / 2
+    DY = TABLE_LENGTH / 2
+    # rotated by +90°
+    corners = [
+        [-DY, -DX, 0],
+        [-DY, DX, 0],
+        [DY, DX, 0],
+        [DY, -DX, 0],
+    ]
+
+    pose = pam_vicon.get_table_pose(corners)
+
+    assert_array_almost_equal(pose.translation, [0, 0, 0])
+    assert_array_almost_equal(pose.rotation.as_euler("XYZ", degrees=True), [0, 0, 90])
+
+
+def test_get_table_pose_transformed():
+    DX = TABLE_WIDTH / 2
+    DY = TABLE_LENGTH / 2
+    # rotated by +90°
+    corners = [
+        [-DY + 1.2, -DX - 0.7, 1.4],
+        [-DY + 1.2, DX - 0.7, 1.4],
+        [DY + 1.2, DX - 0.7, 1.4],
+        [DY + 1.2, -DX - 0.7, 1.4],
+    ]
+
+    pose = pam_vicon.get_table_pose(corners)
+
+    assert_array_almost_equal(pose.translation, [1.2, -0.7, 1.4])
+    assert_array_almost_equal(pose.rotation.as_euler("XYZ", degrees=True), [0, 0, 90])
+
+
+def test_get_table_pose_yaw_only():
+    DX = TABLE_WIDTH / 2
+    DY = TABLE_LENGTH / 2
+    # rotated by +90°
+    corners = [
+        [-DY, -DX, 0],
+        [-DY, DX, 0],
+        [DY, DX, 0],
+        [DY, -DX, 0],
+    ]
+
+    # add rotational perturbation that does not affect Z-axis
+    rot = Rotation.from_euler("XY", (1.2, -0.8), degrees=True)
+    corners = rot.apply(corners)
+
+    pose_full = pam_vicon.get_table_pose(corners)
+    pose_yaw_only = pam_vicon.get_table_pose(corners, yaw_only=True)
+
+    assert_array_almost_equal(
+        pose_full.rotation.as_euler("XYZ", degrees=True), (1.2, -0.8, 90)
+    )
+    assert_array_almost_equal(
+        pose_yaw_only.rotation.as_euler("XYZ", degrees=True), (0, 0, 90)
+    )
+
+
+@pytest.mark.usefixtures("_standalone")
+def test_pam_vicon_poses():
+    pv = pam_vicon.PamVicon(SEGMENT_ID)
+
+    # without calling pv.update() first
+    with pytest.raises(pam_vicon.NoFrameDataError):
+        pv.get_robot_pose()
+
+    pv.update()
+
+    robot = pv.get_robot_pose()
+    table = pv.get_table_pose(yaw_only=False)
+    table_yaw_only = pv.get_table_pose(yaw_only=True)
+
+    assert_array_almost_equal(
+        robot.translation,
+        (
+            1.0833450422755915 - 1.0,
+            0.5051439649956337 - 0.025,
+            0.46859351795065907 + 0.003,
+        ),
+    )
+    assert_array_almost_equal(
+        robot.rotation.as_quat(),
+        (
+            0.9660044056109515,
+            0.25845280471831683,
+            -0.0054959463541859105,
+            -0.002725921337801426,
+        ),
+    )
+
+    assert_array_almost_equal(table.translation, [-1.25398396, 0.02875159, 0.03422968])
+    assert_array_almost_equal(
+        table.rotation.as_euler("XYZ", degrees=True),
+        [-0.16909139, 0.42076322, 110.1044683],
+    )
+
+    assert_array_almost_equal(
+        table_yaw_only.translation, [-1.25398396, 0.02875159, 0.03422968]
+    )
+    assert_array_almost_equal(
+        table_yaw_only.rotation.as_euler("XYZ", degrees=True),
+        [0, 0, 110.1044683],
+    )

--- a/vicon_transformer/__init__.py
+++ b/vicon_transformer/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from .vicon_transformer_bindings import (
     BadResultError,
     NotConnectedError,
+    PlaybackReceiver,
     SubjectData,
     SubjectNotVisibleError,
     UnknownSubjectError,
@@ -44,6 +45,7 @@ class ViconReceiver(_ViconReceiver):
 __all__ = (
     "BadResultError",
     "NotConnectedError",
+    "PlaybackReceiver",
     "SubjectData",
     "SubjectNotVisibleError",
     "UnknownSubjectError",


### PR DESCRIPTION
## Description
The `PamVicon` class is a wrapper around the o80 front end.  It provides methods to access the pose of relevant objects (currently robot and table) without needing to know the specific names of the corresponding Vicon markers.
Also, for the table the pose is computed based on the positions of the corner markers.

`get_scene_configuration.py` is a helper script to print the current poses of relevant objects in JSON format.  It might be useful to safe the current scene configuration but not sure if we really need it.  Can be removed in the future, if it turns out we don't use it.


## How I Tested

Unit tests and running the script.



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
