### PR TITLE
Record synchronised tennicam-vicon-trajectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ install(
 )
 
 install_scripts(
+    scripts/record_tennicam_vicon_trajectory.py
     scripts/vicon_print_data.py
 
     DESTINATION lib/${PROJECT_NAME}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ module = [
     "rclpy.*",
     "scipy.*",
     "signal_handler",
+    "tennicam_client",
     "tf2_ros.*",
     "vicon_dssdk",
     "vicon_transformer.vicon_transformer_bindings",

--- a/scripts/record_tennicam_vicon_trajectory.py
+++ b/scripts/record_tennicam_vicon_trajectory.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-3-Clause
+"""Record a trajectory with both tennicam and Vicon in parallel.
+
+Assumes a ball is attached to the tip of the LED stick, such that the trajectory
+of the ball can be recorded via both tennicam (tracking the ball) and Vicon
+(tracking the LED stick).
+
+The recorded trajectory can then be used to compute a transformation between
+tennicam and Vicon.
+
+Things to consider when recording:
+- Make sure the ball is centred exactly on the tip of the LED stick, so that
+  tennicam and Vicon measure the same position.
+- Move slowly.  Tennicam and Vicon are not exactly synchronised, so better move
+  the ball/stick slowly, to reduce errors introduced by this.
+"""
+import argparse
+import contextlib
+import logging
+import json
+import pathlib
+import sys
+import time
+import typing as t
+
+import numpy as np
+import tqdm
+
+import signal_handler
+import tennicam_client
+from vicon_transformer import pam_vicon_o80
+
+
+class JsonEncoder(json.JSONEncoder):
+    """JSON encoder that handles custom types used here"""
+
+    def default(self, obj: t.Any) -> t.Any:
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        return json.JSONEncoder.default(self, obj)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "destination",
+        type=pathlib.Path,
+        help="File to which the recorded data is written.",
+    )
+    parser.add_argument(
+        "--rate",
+        "-r",
+        type=float,
+        default="1.0",
+        metavar="SECONDS",
+        help="Rate in seconds at which positions are saved.  Default: %(default)s",
+    )
+    parser.add_argument(
+        "--tennicam-segment-id",
+        type=str,
+        default="tennicam_client",
+        help="""Shared memory segment ID used by the tennicam back end.
+            Default: "%(default)s"
+        """,
+    )
+    parser.add_argument(
+        "--vicon-segment-id",
+        type=str,
+        default="vicon",
+        help="""Shared memory segment ID used by the vicon back end.
+            Default: "%(default)s"
+        """,
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Enable verbose output."
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="[%(asctime)s] [%(name)s | %(levelname)s] %(message)s",
+    )
+
+    if args.destination.exists():
+        logging.fatal("Destination file %s already exists.", args.destination)
+        return 1
+
+    logging.debug("Tennicam segment id: %s", args.tennicam_segment_id)
+    logging.debug("Vicon segment id: %s", args.vicon_segment_id)
+    logging.debug("Recording rate: %f seconds", args.rate)
+
+    tennicam_frontend = tennicam_client.FrontEnd(args.tennicam_segment_id)
+    vicon_frontend = pam_vicon_o80.FrontEnd(args.vicon_segment_id)
+
+    data = []
+    signal_handler.init()  # for detecting ctrl+c
+    with contextlib.suppress(KeyboardInterrupt, SystemExit), tqdm.tqdm() as progress:
+        next_update = time.time() + args.rate
+        while not signal_handler.has_received_sigint():
+            now = time.time()
+            sleep_duration = max(0, next_update - now)
+            time.sleep(sleep_duration)
+            next_update += args.rate
+
+            # Tennicam is a bit slower than Vicon (~180 Hz vs 300 Hz).  Therefore, wait
+            # for the next tennicam observation and then immediately get the latest
+            # Vicon observation.  This way, they should be fairly synchronised.
+            logging.debug("tennicam: Wait for next observation.")
+            tennicam_frontend.reset_next_index()
+            obs_tennicam = tennicam_frontend.wait_for_next()
+            logging.debug("vicon: Get latest observation.")
+            obs_vicon = vicon_frontend.latest()
+
+            vicon_frame = obs_vicon.get_extended_state()
+            led_stick = vicon_frame.subjects[pam_vicon_o80.Subjects.LED_STICK]
+
+            if obs_tennicam.get_ball_id() < 0:
+                logging.error("No ball detected.  Skip frame.")
+                continue
+
+            if not led_stick.is_visible:
+                logging.error("LED stick not detected.  Skip frame.")
+                continue
+
+            position_tennicam = obs_tennicam.get_position()
+            position_vicon = led_stick.global_pose.translation
+
+            data.append(
+                {
+                    "tennicam_timestamp": obs_tennicam.get_time_stamp(),
+                    "tennicam_position": position_tennicam,
+                    "vicon_timestamp": vicon_frame.time_stamp,
+                    "vicon_position": position_vicon,
+                }
+            )
+            progress.update()
+
+    logging.debug("Save trajectory to file %s", args.destination)
+    with open(args.destination, "w") as f:
+        json.dump(data, f, cls=JsonEncoder)
+
+    return 0
+
+
+if __name__ == "__main__":
+    with contextlib.suppress(KeyboardInterrupt):
+        sys.exit(main())

--- a/scripts/record_tennicam_vicon_trajectory.py
+++ b/scripts/record_tennicam_vicon_trajectory.py
@@ -14,6 +14,14 @@ Things to consider when recording:
   tennicam and Vicon measure the same position.
 - Move slowly.  Tennicam and Vicon are not exactly synchronised, so better move
   the ball/stick slowly, to reduce errors introduced by this.
+
+Stop the recording by pressing Ctrl+C.  The trajectory is then saved to the specified
+destination path using JSON format.  It is structured as sequence of objects with the
+values
+- "tennicam_position": Position [x, y, z] of the ball as detected by tennicam.
+- "tennicam_timestamp": Timestamp of the tennicam position.
+- "vicon_position:": Position [x, y, z] of the LED stick as detected by tennicam.
+- "vicon_timestamp": Timestamp of the Vicon position.
 """
 import argparse
 import contextlib

--- a/scripts/record_tennicam_vicon_trajectory.py
+++ b/scripts/record_tennicam_vicon_trajectory.py
@@ -117,8 +117,8 @@ def main() -> int:
             # for the next tennicam observation and then immediately get the latest
             # Vicon observation.  This way, they should be fairly synchronised.
             logging.debug("tennicam: Wait for next observation.")
-            tennicam_frontend.reset_next_index()
-            obs_tennicam = tennicam_frontend.wait_for_next()
+            i = tennicam_frontend.latest().iteration
+            obs_tennicam = tennicam_frontend.read(i + 1)
             logging.debug("vicon: Get latest observation.")
             obs_vicon = vicon_frontend.latest()
 

--- a/scripts/record_tennicam_vicon_trajectory.py
+++ b/scripts/record_tennicam_vicon_trajectory.py
@@ -117,7 +117,7 @@ def main() -> int:
             # for the next tennicam observation and then immediately get the latest
             # Vicon observation.  This way, they should be fairly synchronised.
             logging.debug("tennicam: Wait for next observation.")
-            i = tennicam_frontend.latest().iteration
+            i = tennicam_frontend.latest().get_iteration()
             obs_tennicam = tennicam_frontend.read(i + 1)
             logging.debug("vicon: Get latest observation.")
             obs_vicon = vicon_frontend.latest()


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Add new script `record_tennicam_vicon_trajectory.py` that connects to both tennicam_client and pam_vicon to record the trajectory of a ball mounted on the LED stick with both systems (tennicam records the ball positions while Vicon records the LED stick).

Assuming that the ball is mounted at the origin of the LED stick, the resulting trajectory can be used to compute the spatial transformation between the two systems.


## How I Tested

Ran it to record a trajectory.  I did not evaluate the resulting data yet, though.


## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [x] branch fwidmaier/driver_ignore_unknown_subject

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
